### PR TITLE
build: release 0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Notable changes to Syncthing for Omarchy are documented here.
 
 ## Unreleased
 
-## 0.2.0 - 2026-08-20
+## 0.1.5 - 2026-08-20
 
 - Add an optional theme-colored bar icon while keeping the Syncthing artwork
   as the default (@davidszp, @ilyaZar).

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "io.github.ilyazar.syncthing",
   "name": "Syncthing",
-  "version": "0.2.0",
+  "version": "0.1.5",
   "author": "ilyaZar",
   "license": "MIT AND MPL-2.0",
   "description": "See sync health, safely manage folders, control the service, and install Syncthing from the Omarchy bar.",


### PR DESCRIPTION
- correct the release metadata to 0.1.5
- keep the new icon feature on the current patch line