### PR TITLE
fix: follow bar colors and render icons at the host size

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -589,9 +589,6 @@ Panel {
           width: Style.space(12)
           height: width
           source: root.themedIconSource
-          // Not root.foreground: on a transparent bar the host adapts the
-          // icon color to the wallpaper behind it, and every other bar icon
-          // picks that up through WidgetButton's own foreground property.
           tint: button.foreground
         }
 

--- a/Panel.qml
+++ b/Panel.qml
@@ -585,20 +585,16 @@ Panel {
 
         // Keep the effect warm under the brand icon for reliable live switches.
         MonoIcon {
-          anchors.centerIn: parent
-          width: Style.space(12)
-          height: width
+          anchors.fill: parent
           source: root.themedIconSource
           tint: button.foreground
         }
 
         Image {
-          anchors.centerIn: parent
-          width: Style.space(12)
-          height: width
+          anchors.fill: parent
           source: root.syncthingIconSource
-          sourceSize.width: 32
-          sourceSize.height: 32
+          sourceSize.width: width
+          sourceSize.height: height
           fillMode: Image.PreserveAspectFit
           smooth: true
           visible: !root.themedIcon

--- a/Panel.qml
+++ b/Panel.qml
@@ -589,7 +589,10 @@ Panel {
           width: Style.space(12)
           height: width
           source: root.themedIconSource
-          tint: root.foreground
+          // Not root.foreground: on a transparent bar the host adapts the
+          // icon color to the wallpaper behind it, and every other bar icon
+          // picks that up through WidgetButton's own foreground property.
+          tint: button.foreground
         }
 
         Image {

--- a/ui/MonoIcon.qml
+++ b/ui/MonoIcon.qml
@@ -7,11 +7,6 @@ Item {
   property url source
   property color tint: "#ffffff"
 
-  // The mono assets are pure white artwork. MultiEffect's colorization only
-  // swaps hue and saturation and keeps the source lightness, so a white glyph
-  // stays white whatever the tint is -- unreadable against a light bar. Mask a
-  // solid tint rectangle with the artwork's alpha instead: that recolors in
-  // both directions and still antialiases the edges.
   Image {
     id: image
     anchors.fill: parent
@@ -24,22 +19,10 @@ Item {
     layer.enabled: true
   }
 
-  Rectangle {
-    id: tintSource
-    anchors.fill: image
-    color: root.tint
-    visible: false
-    layer.enabled: true
-  }
-
-  // min 0.5 with spread 1.0 makes the mask curve span the full alpha range,
-  // so partially covered edge pixels stay partially covered.
   MultiEffect {
     anchors.fill: image
-    source: tintSource
-    maskEnabled: true
-    maskSource: image
-    maskThresholdMin: 0.5
-    maskSpreadAtMin: 1.0
+    source: image
+    colorization: 1.0
+    colorizationColor: root.tint
   }
 }

--- a/ui/MonoIcon.qml
+++ b/ui/MonoIcon.qml
@@ -7,6 +7,11 @@ Item {
   property url source
   property color tint: "#ffffff"
 
+  // The mono assets are pure white artwork. MultiEffect's colorization only
+  // swaps hue and saturation and keeps the source lightness, so a white glyph
+  // stays white whatever the tint is -- unreadable against a light bar. Mask a
+  // solid tint rectangle with the artwork's alpha instead: that recolors in
+  // both directions and still antialiases the edges.
   Image {
     id: image
     anchors.fill: parent
@@ -19,10 +24,22 @@ Item {
     layer.enabled: true
   }
 
+  Rectangle {
+    id: tintSource
+    anchors.fill: image
+    color: root.tint
+    visible: false
+    layer.enabled: true
+  }
+
+  // min 0.5 with spread 1.0 makes the mask curve span the full alpha range,
+  // so partially covered edge pixels stay partially covered.
   MultiEffect {
     anchors.fill: image
-    source: image
-    colorization: 1.0
-    colorizationColor: root.tint
+    source: tintSource
+    maskEnabled: true
+    maskSource: image
+    maskThresholdMin: 0.5
+    maskSpreadAtMin: 1.0
   }
 }

--- a/ui/MonoIcon.qml
+++ b/ui/MonoIcon.qml
@@ -11,8 +11,8 @@ Item {
     id: image
     anchors.fill: parent
     source: root.source
-    sourceSize.width: Math.round(width * Screen.devicePixelRatio)
-    sourceSize.height: Math.round(height * Screen.devicePixelRatio)
+    sourceSize.width: width
+    sourceSize.height: height
     fillMode: Image.PreserveAspectFit
     smooth: true
     visible: false


### PR DESCRIPTION
the themed status icon now follows the bar foreground, including wallpaper
contrast adjustments on transparent bars. both icon styles use omarchy's
icon canvas and render their svg at the displayed size, so the four status
badges have more room and follow screen scaling.

verified on optiplex-sff with omarchy quattro `e8e92c5`, quickshell 0.3.1,
and qt 6.11.2:

- light and dark wallpapers, with live foreground changes
- flexoki light and tokyo night with opaque and transparent bars
- vantablack with a transparent bar over the stock white wallpaper
- all four states in both icon styles at qt pixel densities 1, 1.25, and 2
- plugin validation, qml lint, and code review

the higher pixel densities were exercised through qt process scaling on the
same monitor. the original svg artwork is retained.
