### PR TITLE
feat: detect the SyncThingy Flatpak installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Notable changes to Syncthing for Omarchy are documented here.
 
 ## Unreleased
 
+- detect Syncthing installed through the SyncThingy Flatpak and read its local
+  API key, in addition to the conventional package installation
+
 ## 0.1.7 - 2026-08-31
 
 - reconcile configured and systemd user-service startup states without changing

--- a/Service.qml
+++ b/Service.qml
@@ -48,6 +48,8 @@ QtObject {
   readonly property string installationState: installation.state
   readonly property string installationLabel: installation.label
   readonly property string executablePath: installation.executablePath
+  readonly property string installationBackend: installation.backend
+  readonly property string installationFlatpakId: installation.flatpakId
   readonly property bool serviceAvailable: installation.serviceAvailable
   readonly property string packageStatus: installation.packageStatus
   readonly property string packageError: installation.packageError
@@ -502,13 +504,12 @@ QtObject {
     phase = "discovering"
     lastError = ""
     _keyOutput = ""
-    apiKeyProcess.command = [
-      executablePath,
-      "cli",
-      "config",
-      "gui",
-      "dump-json"
-    ]
+    apiKeyProcess.command = installationBackend === "flatpak"
+      ? [
+          "flatpak", "run", "--command=syncthing",
+          installationFlatpakId, "cli", "config", "gui", "dump-json"
+        ]
+      : [executablePath, "cli", "config", "gui", "dump-json"]
     apiKeyProcess.running = true
   }
 

--- a/core/InstallationController.qml
+++ b/core/InstallationController.qml
@@ -11,6 +11,8 @@ QtObject {
   property string state: "checking"
   property string label: "Checking"
   property string executablePath: ""
+  property string backend: "path"
+  property string flatpakId: ""
   property bool serviceAvailable: false
   property bool serviceRunning: false
   property string serviceActiveState: "inactive"
@@ -77,6 +79,8 @@ QtObject {
     state = nextState
     label = String(data.label || "Unavailable")
     executablePath = String(data.executable || "")
+    backend = String(data.backend || "path")
+    flatpakId = String(data.flatpakId || "")
     serviceAvailable = data.serviceAvailable === true
     serviceRunning = data.serviceRunning === true
     serviceActiveState = String(data.serviceActiveState || "")

--- a/scripts/syncthing-install.sh
+++ b/scripts/syncthing-install.sh
@@ -34,15 +34,37 @@ operation_running() {
   [[ $pid =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null
 }
 
+flatpak_apps=(
+  "com.github.zocker_160.SyncThingy"
+)
+
+detect_flatpak() {
+  local id=""
+  command -v flatpak >/dev/null 2>&1 || return 1
+  for id in "${flatpak_apps[@]}"; do
+    if flatpak info "$id" >/dev/null 2>&1; then
+      printf '%s\n' "$id"
+      return 0
+    fi
+  done
+  return 1
+}
+
 detect_status() {
-  local active_state="inactive" executable="" executable_path=""
-  local label="Not installed" load_state="not-found" state="missing"
-  local unit_file_state="not-found"
+  local active_state="inactive" backend="path" executable=""
+  local executable_path="" flatpak_id="" label="Not installed"
+  local load_state="not-found" state="missing" unit_file_state="not-found"
 
   executable="$(command -v syncthing 2>/dev/null || true)"
   if [[ -n $executable ]]; then
     executable_path="$(readlink -f -- "$executable" 2>/dev/null || true)"
     [[ -n $executable_path ]] || executable_path="$executable"
+  else
+    flatpak_id="$(detect_flatpak 2>/dev/null || true)"
+    if [[ -n $flatpak_id ]]; then
+      backend="flatpak"
+      executable_path="$flatpak_id (Flatpak)"
+    fi
   fi
 
   load_state="$(service_property LoadState)"
@@ -66,6 +88,8 @@ detect_status() {
     --arg state "$state" \
     --arg label "$label" \
     --arg executable "$executable_path" \
+    --arg backend "$backend" \
+    --arg flatpakId "$flatpak_id" \
     --arg serviceActiveState "$active_state" \
     --arg unitFileState "$unit_file_state" \
     --argjson serviceAvailable \
@@ -78,6 +102,8 @@ detect_status() {
       state: $state,
       label: $label,
       executable: $executable,
+      backend: $backend,
+      flatpakId: $flatpakId,
       serviceAvailable: $serviceAvailable,
       serviceRunning: $serviceRunning,
       serviceActiveState: $serviceActiveState,


### PR DESCRIPTION
## What

Syncthing installed through the **SyncThingy** Flatpak (`com.github.zocker_160.SyncThingy`) was not detected, because the plugin only looked for a `syncthing` binary on `PATH`. This adds Flatpak detection alongside the conventional package install.

## Changes

- `scripts/syncthing-install.sh` — `detect_status()` now falls back to `flatpak info` when `syncthing` is not on `PATH`, reporting `backend: "flatpak"` and `flatpakId`.
- `core/InstallationController.qml` — parses and exposes `backend` and `flatpakId`.
- `Service.qml` — when the backend is Flatpak, discovers the local API key with `flatpak run --command=syncthing <id> cli config gui dump-json` instead of the bare binary.
- `CHANGELOG.md` — note the new detection.

## Why it works

SyncThingy bundles `/app/bin/syncthing` and runs it with the host network shared, listening on the default `127.0.0.1:8384`. Its `cli config gui dump-json` returns the same JSON shape as a conventional install, so the API key and TLS flag are read the same way and no other code paths change. The systemd service toggle stays hidden for Flatpak (no `syncthing.service`), which matches SyncThingy managing its own autostart.

## Verification

- `scripts/syncthing-install.sh status` reports `state: existing`, `backend: flatpak` on a Flatpak-only machine.
- `bash tests/scripts.test.sh` and `bash tests/service-state.test.sh` pass.
- `omarchy plugin validate .` exits clean.