### PR TITLE
Fix sync-preparing status classification

### DIFF
--- a/hosts/omarchy/models/PanelModel.js
+++ b/hosts/omarchy/models/PanelModel.js
@@ -59,7 +59,7 @@ function buildFolderRows(syncthing, homePath) {
       errorDetails: status.errorDetails || [],
       errorCount: errorCount,
       problem: state === "error" || !!status.error || errorCount > 0,
-      syncing: needItems > 0 || state.indexOf("sync") === 0,
+      syncing: needItems > 0 || state === "syncing",
       scanning: state.indexOf("scan") === 0,
       paused: !!folder.paused,
       sharedDeviceCount: sharedDeviceCount,

--- a/tests/run.qml
+++ b/tests/run.qml
@@ -31,6 +31,12 @@ QtObject {
     compare(PanelModel.folderMeta(rows[0]),
       "3 files · local only · Configured label", "folder metadata")
     compare(PanelModel.folderState(rows[0], ""), "SYNCED", "folder state")
+    service.folderStatuses.folder.state = "sync-preparing"
+    compare(PanelModel.buildFolderRows(service, "/home/test")[0].syncing,
+      false, "preparing state without work is not syncing")
+    service.folderStatuses.folder.needTotalItems = 1
+    compare(PanelModel.buildFolderRows(service, "/home/test")[0].syncing,
+      true, "pending items are syncing")
     compare(PanelModel.folderState(rows[0], "", true), "SYNCING",
       "active folder state")
     compare(PanelModel.folderMeta(rows[0], true),

--- a/tests/run.qml
+++ b/tests/run.qml
@@ -34,6 +34,10 @@ QtObject {
     service.folderStatuses.folder.state = "sync-preparing"
     compare(PanelModel.buildFolderRows(service, "/home/test")[0].syncing,
       false, "preparing state without work is not syncing")
+    service.folderStatuses.folder.state = "syncing"
+    compare(PanelModel.buildFolderRows(service, "/home/test")[0].syncing,
+      true, "concrete syncing state is syncing")
+    service.folderStatuses.folder.state = "sync-preparing"
     service.folderStatuses.folder.needTotalItems = 1
     compare(PanelModel.buildFolderRows(service, "/home/test")[0].syncing,
       true, "pending items are syncing")


### PR DESCRIPTION
## Problem

Syncshell classified every Syncthing folder state beginning with `sync` as actively syncing. Syncthing can report `sync-preparing` while it is preparing or processing transient remote updates, even when `needTotalItems` and `needBytes` are zero. The panel therefore flickered between preparing/syncing/scanning and up-to-date despite the folder being synchronized.

## Change

Only report a folder as syncing when it has pending items or Syncthing reports the concrete `syncing` state. Scanning and activity handling remain unchanged.

## Testing

- Added regression coverage for `sync-preparing` with no pending work.
- Added coverage confirming pending items still report syncing.
- Targeted QML model tests pass.
- Architecture contract test passes.
- Omarchy service contract test passes.

## Root cause

The folder projection used `state.indexOf("sync") === 0`, which matched both `syncing` and the transient `sync-preparing` state. That prefix check was broader than the intended active-sync state.